### PR TITLE
Drop support for pancakeswap v1 and add support for BUSD LPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The bot provides a lot of convenience trading features including:
 - Tokens balance and price shown in status messages
 - Price tracking relative to buy transaction
 - Ability to make buy and sell limit orders including trailing stop loss
-- Automatic smart price selection in case PancakeSwap v1 and v2 LPs are available
+- Automatic smart price selection in case liquidity is available in BNB and BUSD (list could be extended in the future)
 - Automatic approval for selling
 - Assign emoji to each token to differentiate them easily
 - Default slippage set on a token basis for faster order creation
@@ -84,12 +84,12 @@ The other most useful command is the `/status` command that will display all you
 The script looks for a file named `config.yml` located inside the `user_data`folder by default.
 You can pass another file path to the `trade` command as a positional argument.
 
-The only parameter that is not self-explanatory is `min_pool_size_bnb`. Since PancakeSwap migrated to version 2, some
-tokens have Liquidity Pairs (LP) on both v1 and v2. As a result, the price might be better for buying or selling on
-one version versus the other.
-However, sometimes the LP on a given version has very little liquidity, which means that the price is very volatile.
-In order to avoid swapping on the version that has little liquidity, the bot checks that at least `min_pool_size_bnb`
-is staked in the LP. If that's not the case, the bot will use the other version even if the price is worse.
+The only parameter that is not self-explanatory is `min_pool_size_bnb`. Some tokens have multiple liquidity pools with
+different pairs, like BNB and BUSD.
+However, sometimes the LP with a given base token has very little liquidity, which means that the price is very volatile
+and price impact is large.
+In order to avoid swapping on the pair that has little liquidity, the bot checks that at least `min_pool_size_bnb`
+is staked in the LP. If that's not the case, the bot will use another LP when possible.
 
 The `update_messages` parameter will update the status messages every 30 seconds if set to `true`.
 If you have trouble with the inline buttons not working, this means this bot token is not able to update messages anymore.

--- a/pancaketrade/bot.py
+++ b/pancaketrade/bot.py
@@ -199,28 +199,26 @@ class TradeBot:
             chat_message(update, context, text='⛔️ Invalid token address.', edit=self.config.update_messages)
             return
         token = self.watchers[token_address]
-        _, v2 = self.net.get_token_price(token_address=token.address, token_decimals=token.decimals, sell=True)
-        version = 'v2' if v2 else 'v1'
-        if token.net.is_approved(token.address, v2=v2):
+        if token.net.is_approved(token.address):
             chat_message(
                 update,
                 context,
-                text=f'{token.symbol} is already approved on PancakeSwap {version}',
+                text=f'{token.symbol} is already approved on PancakeSwap',
                 edit=self.config.update_messages,
             )
             return
         chat_message(
             update,
             context,
-            text=f'Approving {token.symbol} for trading on PancakeSwap {version}...',
+            text=f'Approving {token.symbol} for trading on PancakeSwap...',
             edit=self.config.update_messages,
         )
-        approved = token.approve(v2=v2)
+        approved = token.approve()
         if approved:
             chat_message(
                 update,
                 context,
-                text=f'✅ Approval successful on PancakeSwap {version}!',
+                text='✅ Approval successful on PancakeSwap!',
                 edit=self.config.update_messages,
             )
         else:
@@ -320,21 +318,17 @@ class TradeBot:
                 )
 
     def get_token_status(self, token: TokenWatcher) -> Tuple[str, Decimal]:
-        token_price, lp_v2 = self.net.get_token_price(
-            token_address=token.address, token_decimals=token.decimals, sell=True
-        )
+        token_price, base_token_address = self.net.get_token_price(token_address=token.address)
         chart_links = [
             f'<a href="https://poocoin.app/tokens/{token.address}">Poocoin</a>',
             f'<a href="https://charts.bogged.finance/?token={token.address}">Bogged</a>',
             f'<a href="https://dex.guru/token/{token.address}-bsc">Dex.Guru</a>',
         ]
-        token_lp = self.net.find_lp_address(token_address=token.address, v2=lp_v2)
+        token_lp = self.net.find_lp_address(token_address=token.address, base_token_address=base_token_address)
         if token_lp:
             chart_links.append(f'<a href="https://www.dextools.io/app/pancakeswap/pair-explorer/{token_lp}">Dext</a>')
         chart_links.append(f'<a href="https://bscscan.com/token/{token.address}?a={self.net.wallet}">BscScan</a>')
-        token_price_usd = self.net.get_token_price_usd(
-            token_address=token.address, token_decimals=token.decimals, sell=True, token_price=token_price
-        )
+        token_price_usd = self.net.get_token_price_usd(token_address=token.address, token_price=token_price)
         token_balance = self.net.get_token_balance(token_address=token.address)
         token_balance_bnb = self.net.get_token_balance_bnb(
             token_address=token.address, balance=token_balance, token_price=token_price

--- a/pancaketrade/conversations/addorder.py
+++ b/pancaketrade/conversations/addorder.py
@@ -113,9 +113,7 @@ class AddOrderConversation:
             order['trailing_stop'] = None
             # we don't use trailing stop loss here
             token = self.parent.watchers[order['token_address']]
-            current_price, _ = self.net.get_token_price(
-                token_address=token.address, token_decimals=token.decimals, sell=True
-            )
+            current_price, _ = self.net.get_token_price(token_address=token.address)
             chat_message(
                 update,
                 context,
@@ -165,9 +163,7 @@ class AddOrderConversation:
         assert context.user_data is not None
         order = context.user_data['addorder']
         token = self.parent.watchers[order['token_address']]
-        current_price, _ = self.net.get_token_price(
-            token_address=token.address, token_decimals=token.decimals, sell=order['type'] == 'sell'
-        )
+        current_price, _ = self.net.get_token_price(token_address=token.address)
         next_message = self.get_price_message(current_price=current_price, token_symbol=token.symbol)
         if update.message is None:
             assert update.callback_query
@@ -224,9 +220,7 @@ class AddOrderConversation:
             except Exception:
                 chat_message(update, context, text='⚠️ The factor you inserted is not valid. Try again:', edit=False)
                 return self.next.PRICE
-            current_price, _ = self.net.get_token_price(
-                token_address=token.address, token_decimals=token.decimals, sell=order['type'] == 'sell'
-            )
+            current_price, _ = self.net.get_token_price(token_address=token.address)
             price = factor * current_price
         else:
             try:

--- a/pancaketrade/conversations/addtoken.py
+++ b/pancaketrade/conversations/addtoken.py
@@ -181,8 +181,7 @@ class AddTokenConversation:
                 InlineKeyboardButton('💰 Buy/Sell now', callback_data=f'buysell:{token.address}'),
             ]
         ]
-        _, v2 = self.net.get_token_price(token_address=token.address, token_decimals=token.decimals, sell=True)
-        if not self.net.is_approved(token_address=token.address, v2=v2):
+        if not self.net.is_approved(token_address=token.address):
             buttons.append([InlineKeyboardButton('☑️ Approve for selling', callback_data=f'approve:{token.address}')])
         reply_markup = InlineKeyboardMarkup(buttons)
         chat_message(

--- a/pancaketrade/conversations/buysell.py
+++ b/pancaketrade/conversations/buysell.py
@@ -241,9 +241,7 @@ class BuySellConversation:
                     return self.next.AMOUNT
         decimals = 18 if order['type'] == 'buy' else token.decimals
         bnb_price = self.net.get_bnb_price()
-        current_price, _ = self.net.get_token_price(
-            token_address=token.address, token_decimals=token.decimals, sell=order['type'] == 'sell'
-        )
+        current_price, _ = self.net.get_token_price(token_address=token.address)
         usd_amount = bnb_price * amount if order['type'] == 'buy' else bnb_price * current_price * amount
         unit = f'BNB worth of {token.symbol}' if order['type'] == 'buy' else token.symbol
         order['amount'] = str(int(amount * Decimal(10 ** decimals)))
@@ -265,9 +263,7 @@ class BuySellConversation:
         trailing = (
             f'Trailing stop loss {order["trailing_stop"]}% callback\n' if order["trailing_stop"] is not None else ''
         )
-        current_price, _ = self.net.get_token_price(
-            token_address=token.address, token_decimals=token.decimals, sell=order['type'] == 'sell'
-        )
+        current_price, _ = self.net.get_token_price(token_address=token.address)
         bnb_price = self.net.get_bnb_price()
         usd_amount = bnb_price * amount if order['type'] == 'buy' else bnb_price * current_price * amount
         message = (

--- a/pancaketrade/conversations/edittoken.py
+++ b/pancaketrade/conversations/edittoken.py
@@ -126,9 +126,7 @@ class EditTokenConversation:
             )
             return self.next.SLIPPAGE
         elif query.data == 'buyprice':
-            current_price, _ = self.net.get_token_price(
-                token_address=token.address, token_decimals=token.decimals, sell=True
-            )
+            current_price, _ = self.net.get_token_price(token_address=token.address)
             current_price_fixed = format_price_fixed(current_price)
             buttons2 = [
                 [InlineKeyboardButton('No price (disable profit calc)', callback_data='None')],

--- a/pancaketrade/conversations/sellall.py
+++ b/pancaketrade/conversations/sellall.py
@@ -67,18 +67,16 @@ class SellAllConversation:
             chat_message(update, context, text='⛔️ Invalid token address.', edit=self.config.update_messages)
             return ConversationHandler.END
         token: TokenWatcher = self.parent.watchers[query.data]
-        _, v2 = self.net.get_token_price(token_address=token.address, token_decimals=token.decimals, sell=True)
-        if not self.net.is_approved(token_address=token.address, v2=v2):
+        if not self.net.is_approved(token_address=token.address):
             # when selling we require that the token is approved on pcs beforehand
-            version = 'v2' if v2 else 'v1'
-            logger.info(f'Need to approve {token.symbol} for trading on PancakeSwap {version}.')
+            logger.info(f'Need to approve {token.symbol} for trading on PancakeSwap.')
             chat_message(
                 update,
                 context,
-                text=f'Approving {token.symbol} for trading on PancakeSwap {version}...',
+                text=f'Approving {token.symbol} for trading on PancakeSwap...',
                 edit=self.config.update_messages,
             )
-            res = self.net.approve(token_address=token.address, v2=v2)
+            res = self.net.approve(token_address=token.address)
             if res:
                 chat_message(update, context, text='✅ Approval successful!', edit=self.config.update_messages)
             else:
@@ -97,7 +95,6 @@ class SellAllConversation:
             amount_tokens=balance_tokens,
             slippage_percent=token.default_slippage,
             gas_price='+20.1',
-            v2=v2,
         )
         if not res:
             logger.error(f'Transaction failed: {txhash_or_error}')

--- a/pancaketrade/network/bsc.py
+++ b/pancaketrade/network/bsc.py
@@ -230,7 +230,9 @@ class Network:
         return bnb_per_token
 
     @cached(cache=TTLCache(maxsize=1, ttl=30))
-    def get_base_token_price(self, token: Contract):
+    def get_base_token_price(self, token: Contract) -> Decimal:
+        if token.address == self.addr.wbnb:
+            return Decimal(1)
         lp = self.find_lp_address(token.address, self.addr.wbnb)
         if not lp:
             return Decimal(0)

--- a/pancaketrade/network/bsc.py
+++ b/pancaketrade/network/bsc.py
@@ -1,7 +1,7 @@
 import time
 from decimal import Decimal
 from pathlib import Path
-from typing import Dict, NamedTuple, Optional, Set, Tuple
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple
 
 import requests
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -14,7 +14,7 @@ from web3 import Web3
 from web3.contract import Contract, ContractFunction
 from web3.exceptions import ABIFunctionNotFound, ContractLogicError
 from web3.middleware import geth_poa_middleware
-from web3.types import BlockIdentifier, ChecksumAddress, HexBytes, Nonce, TxParams, TxReceipt, Wei
+from web3.types import ChecksumAddress, HexBytes, Nonce, TxParams, TxReceipt, Wei
 
 GAS_LIMIT_FAILSAFE = Wei(2000000)  # if the estimated limit is above this one, don't use the estimated price
 
@@ -75,8 +75,9 @@ class Network:
         self.max_approval_check_hex = f"0x{15 * '0'}{49 * 'f'}"
         self.max_approval_check_int = int(self.max_approval_check_hex, 16)
         self.last_nonce = self.w3.eth.get_transaction_count(self.wallet)
-        self.approved: Set[Tuple[str, bool]] = set()  # address and v2 boolean tuples
-        self.lp_cache: Dict[Tuple[str, bool], ChecksumAddress] = {}  # address and v2 boolean tuples as the key
+        self.approved: Set[str] = set()  # token that were already approved
+        self.lp_cache: Dict[Tuple[str, str], ChecksumAddress] = {}  # token and base tuples as the key
+        self.supported_base_tokens: List[ChecksumAddress] = [self.addr.wbnb, self.addr.busd]
         self.nonce_scheduler = BackgroundScheduler(
             job_defaults={
                 'coalesce': True,
@@ -138,102 +139,119 @@ class Network:
     def get_token_price_usd(
         self,
         token_address: ChecksumAddress,
-        token_decimals: Optional[int] = None,
-        sell: bool = True,
         token_price: Optional[Decimal] = None,
     ) -> Decimal:
         if token_price is None:
-            token_price, _ = self.get_token_price(token_address=token_address, token_decimals=token_decimals, sell=sell)
+            token_price, _ = self.get_token_price(token_address=token_address)
         usd_per_bnb = self.get_bnb_price()
         return token_price * usd_per_bnb
 
-    @cached(cache=TTLCache(maxsize=256, ttl=1))
-    def get_token_price(
-        self, token_address: ChecksumAddress, token_decimals: Optional[int] = None, sell: bool = True
-    ) -> Tuple[Decimal, bool]:
-        if token_address == self.addr.wbnb:  # special case for wbnb
-            return Decimal(1), True
-        if token_decimals is None:
-            token_decimals = self.get_token_decimals(token_address=token_address)
-        token_contract = self.get_token_contract(token_address)
-        lp_v1 = self.find_lp_address(token_address=token_address, v2=False)
-        lp_v2 = self.find_lp_address(token_address=token_address, v2=True)
-        if lp_v1 is None and lp_v2 is None:  # no lp
-            return Decimal(0), True
-        elif lp_v2 is None and lp_v1:  # only v1
-            return (
-                self.get_token_price_by_lp(
-                    token_contract=token_contract, token_lp=lp_v1, token_decimals=token_decimals, ignore_poolsize=True
-                ),
-                False,
-            )
-        elif lp_v1 is None and lp_v2:  # only v2
-            return (
-                self.get_token_price_by_lp(
-                    token_contract=token_contract, token_lp=lp_v2, token_decimals=token_decimals, ignore_poolsize=True
-                ),
-                True,
-            )
-        # both exist
-        assert lp_v1 and lp_v2
-        price_v1 = self.get_token_price_by_lp(
-            token_contract=token_contract, token_lp=lp_v1, token_decimals=token_decimals
-        )
-        price_v2 = self.get_token_price_by_lp(
-            token_contract=token_contract, token_lp=lp_v2, token_decimals=token_decimals
-        )
-        # if the BNB in pool or tokens in pool is zero, we get a price of zero. Also if LP is too empty
-        if price_v1 == 0 and price_v2 == 0:  # both lp's are too small, we choose the largest
-            biggest_lp, v2 = self.get_biggest_lp(lp1=lp_v1, lp2=lp_v2)
-            return (
-                self.get_token_price_by_lp(
-                    token_contract=token_contract,
-                    token_lp=biggest_lp,
-                    token_decimals=token_decimals,
-                    ignore_poolsize=True,
-                ),
-                v2,
-            )
-        elif price_v1 == 0:
-            return price_v2, True
-        elif price_v2 == 0:
-            return price_v1, False
-
+    def get_best_swap_path(
+        self, token_address: ChecksumAddress, amount_in: Wei, sell: bool
+    ) -> Tuple[List[ChecksumAddress], Wei]:
         if sell:
-            return max(price_v1, price_v2), price_v2 > price_v1
-        return min(price_v1, price_v2), price_v2 < price_v1
+            paths = [[token_address, self.addr.wbnb]]
+            for base_token_address in [bt for bt in self.supported_base_tokens if bt != self.addr.wbnb]:
+                paths.append([token_address, base_token_address, self.addr.wbnb])
+        else:
+            paths = [[self.addr.wbnb, token_address]]
+            for base_token_address in [bt for bt in self.supported_base_tokens if bt != self.addr.wbnb]:
+                paths.append([self.addr.wbnb, base_token_address, token_address])
+        amounts_out: List[Wei] = []
+        valid_paths: List[List[ChecksumAddress]] = []
+        for path in paths:
+            try:
+                amount_out = self.contracts.router_v2.functions.getAmountsOut(amount_in, path).call()[-1]
+            except ContractLogicError:  # invalid pair
+                continue
+            amounts_out.append(amount_out)
+            valid_paths.append(path)
+        if not valid_paths:
+            raise ValueError('No valid pair was found')
+        argmax = max(range(len(amounts_out)), key=lambda i: amounts_out[i])
+        return valid_paths[argmax], amounts_out[argmax]
 
-    def get_token_price_by_lp(
+    @cached(cache=TTLCache(maxsize=256, ttl=1))
+    def get_token_price(self, token_address: ChecksumAddress) -> Tuple[Decimal, ChecksumAddress]:
+        """Return price of the token in BNB/token.
+
+        [extended_summary]
+
+        Args:
+            token_address (ChecksumAddress): the address of the token
+
+        Returns:
+            Tuple[Decimal, ChecksumAddress]: a tuple containing:
+                - Decimal: price of the token in BNB
+                - ChecksumAddress: the base token of the biggest LP
+        """
+        if token_address == self.addr.wbnb:  # special case for wbnb
+            return Decimal(1), self.addr.wbnb
+        token = self.get_token_contract(token_address)
+        all_lps = [
+            self.find_lp_address(token_address=token_address, base_token_address=base_token_address)
+            for base_token_address in self.supported_base_tokens
+        ]
+        supported_lps = [lp for lp in all_lps if lp is not None]  # filter out non-existent LPs
+        if not supported_lps:  # token is not trading yet
+            return Decimal(0), self.addr.wbnb
+        _, lp_index = self.find_biggest_lp(token, lps=supported_lps)
+        base_token_address = self.supported_base_tokens[lp_index]
+        base_token = self.get_token_contract(base_token_address)
+        return self.get_token_price_for_lp(token, base_token, ignore_poolsize=True), base_token_address
+
+    def get_token_price_for_lp(
         self,
-        token_contract: Contract,
-        token_lp: ChecksumAddress,
-        token_decimals: int,
+        token: Contract,
+        base_token: Contract,
         ignore_poolsize: bool = False,
-        block_identifier: BlockIdentifier = 'latest',
     ) -> Decimal:
-        lp_bnb_amount = Decimal(
-            self.contracts.wbnb.functions.balanceOf(token_lp).call(block_identifier=block_identifier)
-        )
-        if lp_bnb_amount / Decimal(10 ** 18) < self.min_pool_size_bnb and not ignore_poolsize:  # not enough liquidity
+        """Return the price in BNB per token, regardless of the base token of the LP."""
+        lp = self.find_lp_address(token_address=token.address, base_token_address=base_token.address)
+        if lp is None:
             return Decimal(0)
-        lp_token_amount = Decimal(
-            token_contract.functions.balanceOf(token_lp).call(block_identifier=block_identifier)
-        ) * Decimal(10 ** (18 - token_decimals))
-        # normalize to 18 decimals
+        base_decimals = self.get_token_decimals(base_token.address)
+        base_amount = Decimal(base_token.functions.balanceOf(lp).call()) * Decimal(
+            10 ** (18 - base_decimals)
+        )  # e.g. balance of LP in BUSD, normalized to 18 decimals
+        base_per_bnb = self.get_base_token_price(base_token)  # e.g. price of BUSD in BNB/BUSD
+        base_amount_in_bnb = base_amount * base_per_bnb
+        if (
+            base_amount_in_bnb / Decimal(10 ** 18) < self.min_pool_size_bnb and not ignore_poolsize
+        ):  # not enough liquidity
+            return Decimal(0)
+        token_decimals = self.get_token_decimals(token.address)
+        token_amount = Decimal(token.functions.balanceOf(lp).call()) * Decimal(10 ** (18 - token_decimals))
+        # normalize decimals
         try:
-            bnb_per_token = lp_bnb_amount / lp_token_amount
+            bnb_per_token = base_amount_in_bnb / token_amount
         except Exception:
             bnb_per_token = Decimal(0)
         return bnb_per_token
 
     @cached(cache=TTLCache(maxsize=1, ttl=30))
+    def get_base_token_price(self, token: Contract):
+        lp = self.find_lp_address(token.address, self.addr.wbnb)
+        if not lp:
+            return Decimal(0)
+        token_decimals = self.get_token_decimals(token.address)
+        bnb_amount = Decimal(self.contracts.wbnb.functions.balanceOf(lp).call())
+        token_amount = Decimal(token.functions.balanceOf(lp).call()) * Decimal(10 ** (18 - token_decimals))
+        return bnb_amount / token_amount
+
+    @cached(cache=TTLCache(maxsize=1, ttl=30))
     def get_bnb_price(self) -> Decimal:
-        lp = self.find_lp_address(token_address=self.addr.busd, v2=True)
+        lp = self.find_lp_address(token_address=self.addr.busd, base_token_address=self.addr.wbnb)
         if not lp:
             return Decimal(0)
         bnb_amount = Decimal(self.contracts.wbnb.functions.balanceOf(lp).call())
         busd_amount = Decimal(self.contracts.busd.functions.balanceOf(lp).call())
         return busd_amount / bnb_amount
+
+    def find_biggest_lp(self, token: Contract, lps: List[ChecksumAddress]) -> Tuple[ChecksumAddress, int]:
+        lp_balances = [Decimal(token.functions.balanceOf(lp).call()) for lp in lps]
+        argmax = max(range(len(lp_balances)), key=lambda i: lp_balances[i])
+        return lps[argmax], argmax
 
     @cached(cache=LRUCache(maxsize=256))
     def get_token_decimals(self, token_address: ChecksumAddress) -> int:
@@ -247,55 +265,42 @@ class Network:
         symbol = token_contract.functions.symbol().call()
         return symbol
 
-    def get_biggest_lp(self, lp1: ChecksumAddress, lp2: ChecksumAddress) -> Tuple[ChecksumAddress, bool]:
-        bnb_amount1 = Decimal(self.contracts.wbnb.functions.balanceOf(lp1).call())
-        bnb_amount2 = Decimal(self.contracts.wbnb.functions.balanceOf(lp2).call())
-        if bnb_amount1 > bnb_amount2:
-            return lp1, False
-        return lp2, True
-
     @cached(cache=LRUCache(maxsize=256))
     def get_token_contract(self, token_address: ChecksumAddress) -> Contract:
         with Path('pancaketrade/abi/bep20.abi').open('r') as f:
             abi = f.read()
         return self.w3.eth.contract(address=token_address, abi=abi)
 
-    def find_lp_address(self, token_address: ChecksumAddress, v2: bool = False) -> Optional[ChecksumAddress]:
-        cached = self.lp_cache.get((str(token_address), v2))
+    def find_lp_address(
+        self, token_address: ChecksumAddress, base_token_address: ChecksumAddress
+    ) -> Optional[ChecksumAddress]:
+        cached = self.lp_cache.get((str(token_address), str(base_token_address)))
         if cached is not None:
             return cached
-        contract = self.contracts.factory_v2 if v2 else self.contracts.factory_v1
-        pair = contract.functions.getPair(token_address, self.addr.wbnb).call()
+        pair = self.contracts.factory_v2.functions.getPair(token_address, base_token_address).call()
         if pair == '0x' + 40 * '0':  # not found, don't cache
             return None
         checksum_pair = Web3.toChecksumAddress(pair)
-        self.lp_cache[(str(token_address), v2)] = checksum_pair
+        self.lp_cache[(str(token_address), str(base_token_address))] = checksum_pair
         return checksum_pair
-
-    def has_both_versions(self, token_address: ChecksumAddress) -> bool:
-        lp_v1 = self.find_lp_address(token_address=token_address, v2=False)
-        lp_v2 = self.find_lp_address(token_address=token_address, v2=True)
-        return lp_v1 is not None and lp_v2 is not None
 
     def get_gas_price(self) -> Wei:
         return self.w3.eth.gas_price
 
-    def is_approved(self, token_address: ChecksumAddress, v2: bool = False) -> bool:
-        if (str(token_address), v2) in self.approved:
+    def is_approved(self, token_address: ChecksumAddress) -> bool:
+        if str(token_address) in self.approved:
             return True
         token_contract = self.get_token_contract(token_address=token_address)
-        router_address = self.addr.router_v2 if v2 else self.addr.router_v1
-        amount = token_contract.functions.allowance(self.wallet, router_address).call()
+        amount = token_contract.functions.allowance(self.wallet, self.addr.router_v2).call()
         approved = amount >= self.max_approval_check_int
         if approved:
-            self.approved.add((str(token_address), v2))
+            self.approved.add(str(token_address))
         return approved
 
-    def approve(self, token_address: ChecksumAddress, v2: bool = False, max_approval: Optional[int] = None) -> bool:
+    def approve(self, token_address: ChecksumAddress, max_approval: Optional[int] = None) -> bool:
         max_approval = self.max_approval_int if not max_approval else max_approval
         token_contract = self.get_token_contract(token_address=token_address)
-        router_address = self.addr.router_v2 if v2 else self.addr.router_v1
-        func = token_contract.functions.approve(router_address, max_approval)
+        func = token_contract.functions.approve(self.addr.router_v2, max_approval)
         logger.info(f'Approving {self.get_token_symbol(token_address=token_address)} - {token_address}...')
         try:
             gas_limit = Wei(int(Decimal(func.estimateGas({'from': self.wallet, 'value': Wei(0)})) * Decimal(1.2)))
@@ -310,7 +315,7 @@ class Network:
         if receipt['status'] == 0:  # fail
             logger.error(f'Approval call failed at tx {Web3.toHex(primitive=receipt["transactionHash"])}')
             return False
-        self.approved.add((str(token_address), v2))
+        self.approved.add(str(token_address))
         time.sleep(3)  # let tx propagate
         logger.success('Approved wallet for trading.')
         return True
@@ -321,7 +326,6 @@ class Network:
         amount_bnb: Wei,
         slippage_percent: Decimal,
         gas_price: Optional[str],
-        v2: bool = True,
     ) -> Tuple[bool, Decimal, str]:
         balance_bnb = self.w3.eth.get_balance(self.wallet)
         if amount_bnb > balance_bnb - Wei(2000000000000000):  # leave 0.002 BNB for future gas fees
@@ -334,15 +338,20 @@ class Network:
             final_gas_price = Wei(final_gas_price + offset)
         elif gas_price is not None:
             final_gas_price = Web3.toWei(gas_price, unit='wei')
-        router_contract = self.contracts.router_v2 if v2 else self.contracts.router_v1
-        predicted_out = router_contract.functions.getAmountsOut(amount_bnb, [self.addr.wbnb, token_address]).call()[-1]
+        try:
+            best_path, predicted_out = self.get_best_swap_path(
+                token_address=token_address, amount_in=amount_bnb, sell=False
+            )
+        except ValueError as e:
+            logger.error(e)
+            return (
+                False,
+                Decimal(0),
+                'No compatible LP was found',
+            )
         min_output_tokens = Web3.toWei(slippage_ratio * predicted_out, unit='wei')
         receipt = self.buy_tokens_with_params(
-            token_address=token_address,
-            amount_bnb=amount_bnb,
-            min_output_tokens=min_output_tokens,
-            gas_price=final_gas_price,
-            v2=v2,
+            path=best_path, amount_bnb=amount_bnb, min_output_tokens=min_output_tokens, gas_price=final_gas_price
         )
         if receipt is None:
             logger.error('Can\'t get gas estimate')
@@ -369,15 +378,13 @@ class Network:
 
     def buy_tokens_with_params(
         self,
-        token_address: ChecksumAddress,
+        path: List[ChecksumAddress],
         amount_bnb: Wei,
         min_output_tokens: Wei,
         gas_price: Wei,
-        v2: bool,
     ) -> Optional[TxReceipt]:
-        router_contract = self.contracts.router_v2 if v2 else self.contracts.router_v1
-        func = router_contract.functions.swapExactETHForTokensSupportingFeeOnTransferTokens(
-            min_output_tokens, [self.addr.wbnb, token_address], self.wallet, self.deadline(60)
+        func = self.contracts.router_v2.functions.swapExactETHForTokensSupportingFeeOnTransferTokens(
+            min_output_tokens, path, self.wallet, self.deadline(60)
         )
         try:
             gas_limit = Wei(int(Decimal(func.estimateGas({'from': self.wallet, 'value': amount_bnb})) * Decimal(1.2)))
@@ -391,12 +398,7 @@ class Network:
         return self.w3.eth.wait_for_transaction_receipt(tx, timeout=60)
 
     def sell_tokens(
-        self,
-        token_address: ChecksumAddress,
-        amount_tokens: Wei,
-        slippage_percent: Decimal,
-        gas_price: Optional[str],
-        v2: bool = True,
+        self, token_address: ChecksumAddress, amount_tokens: Wei, slippage_percent: Decimal, gas_price: Optional[str]
     ) -> Tuple[bool, Decimal, str]:
         balance_tokens = self.get_token_balance_wei(token_address=token_address)
         amount_tokens = min(amount_tokens, balance_tokens)  # partially fill order if possible
@@ -407,17 +409,20 @@ class Network:
             final_gas_price = Wei(final_gas_price + offset)
         elif gas_price is not None:
             final_gas_price = Web3.toWei(gas_price, unit='wei')
-        router_contract = self.contracts.router_v2 if v2 else self.contracts.router_v1
-        predicted_out = router_contract.functions.getAmountsOut(amount_tokens, [token_address, self.addr.wbnb]).call()[
-            -1
-        ]
+        try:
+            best_path, predicted_out = self.get_best_swap_path(
+                token_address=token_address, amount_in=amount_tokens, sell=True
+            )
+        except ValueError as e:
+            logger.error(e)
+            return (
+                False,
+                Decimal(0),
+                'No compatible LP was found',
+            )
         min_output_bnb = Web3.toWei(slippage_ratio * predicted_out, unit='wei')
         receipt = self.sell_tokens_with_params(
-            token_address=token_address,
-            amount_tokens=amount_tokens,
-            min_output_bnb=min_output_bnb,
-            gas_price=final_gas_price,
-            v2=v2,
+            path=best_path, amount_tokens=amount_tokens, min_output_bnb=min_output_bnb, gas_price=final_gas_price
         )
         if receipt is None:
             logger.error('Can\'t get gas estimate')
@@ -435,7 +440,7 @@ class Network:
         for log in reversed(logs):  # only get last withdrawal call
             if log['address'] != self.addr.wbnb:
                 continue
-            if log['args']['src'] != router_contract.address:
+            if log['args']['src'] != self.addr.router_v2:
                 continue
             amount_out = Decimal(Web3.fromWei(log['args']['wad'], unit='ether'))
             break
@@ -444,15 +449,13 @@ class Network:
 
     def sell_tokens_with_params(
         self,
-        token_address: ChecksumAddress,
+        path: List[ChecksumAddress],
         amount_tokens: Wei,
         min_output_bnb: Wei,
         gas_price: Wei,
-        v2: bool,
     ) -> Optional[TxReceipt]:
-        router_contract = self.contracts.router_v2 if v2 else self.contracts.router_v1
-        func = router_contract.functions.swapExactTokensForETHSupportingFeeOnTransferTokens(
-            amount_tokens, min_output_bnb, [token_address, self.addr.wbnb], self.wallet, self.deadline(60)
+        func = self.contracts.router_v2.functions.swapExactTokensForETHSupportingFeeOnTransferTokens(
+            amount_tokens, min_output_bnb, path, self.wallet, self.deadline(60)
         )
         try:
             gas_limit = Wei(int(Decimal(func.estimateGas({'from': self.wallet, 'value': Wei(0)})) * Decimal(1.2)))

--- a/pancaketrade/watchers/token.py
+++ b/pancaketrade/watchers/token.py
@@ -63,31 +63,20 @@ class TokenWatcher:
         self.update_effective_buy_price()
         if not self.orders:
             return
-        sell_price, sell_v2 = self.net.get_token_price(
-            token_address=self.address, token_decimals=self.decimals, sell=True
-        )
-        if self.net.has_both_versions(token_address=self.address):
-            buy_price, buy_v2 = self.net.get_token_price(
-                token_address=self.address, token_decimals=self.decimals, sell=False
-            )
-        else:
-            buy_price = sell_price
-            buy_v2 = sell_v2
+        price, _ = self.net.get_token_price(token_address=self.address)
         indices_to_remove: List[int] = []
         for i, order in enumerate(self.orders):
             if order.finished:
                 indices_to_remove.append(i)
                 continue
-            v2 = buy_v2 if order.type == 'buy' else sell_v2
-            if not self.net.is_approved(token_address=self.address, v2=v2) and order.type == 'sell':
+            if not self.net.is_approved(token_address=self.address) and order.type == 'sell':
                 # when selling we require that the token is approved on pcs beforehand
-                version = 'v2' if v2 else 'v1'
-                logger.info(f'Need to approve {self.symbol} for trading on PancakeSwap {version}.')
+                logger.info(f'Need to approve {self.symbol} for trading on PancakeSwap.')
                 self.dispatcher.bot.send_message(
                     chat_id=self.config.secrets.admin_chat_id,
-                    text=f'Approving {self.symbol} for trading on PancakeSwap {version}...',
+                    text=f'Approving {self.symbol} for trading on PancakeSwap...',
                 )
-                res = self.net.approve(token_address=self.address, v2=v2)
+                res = self.net.approve(token_address=self.address)
                 if res:
                     self.dispatcher.bot.send_message(
                         chat_id=self.config.secrets.admin_chat_id,
@@ -98,7 +87,7 @@ class TokenWatcher:
                         chat_id=self.config.secrets.admin_chat_id,
                         text='⛔ Approval failed',
                     )
-            order.price_update(sell_price=sell_price, buy_price=buy_price, sell_v2=sell_v2, buy_v2=buy_v2)
+            order.price_update(price=price)
         self.orders = [o for i, o in enumerate(self.orders) if i not in indices_to_remove]
 
     def update_effective_buy_price(self):
@@ -106,5 +95,5 @@ class TokenWatcher:
             Decimal(self.token_record.effective_buy_price) if self.token_record.effective_buy_price else None
         )
 
-    def approve(self, v2: bool = False) -> bool:
-        return self.net.approve(self.address, v2=v2)
+    def approve(self) -> bool:
+        return self.net.approve(self.address)


### PR DESCRIPTION
This refactor adds support for BUSD LPs (more base tokens can easily be added in the future) and uses "multihops" to find the best price when a token has BNB as well as BUSD liquidity.

In order to keep complexity down, support for pancakeswap v1 was dropped.

The price finding (routing) algorithm is quite simple.

At the moment of buying a token, the following paths will be compared in terms of their output amounts:
- BNB -> token
- BNB -> BUSD -> token (at the moment, only BUSD is used, to keep the number of requests to a minimum)

The path with the higher output amount will be used for swapping

At the moment of selling a token, the following paths will be compared in terms of their output amounts:
- token -> BNB
- token -> BUSD -> BNB (at the moment, only BUSD is used, to keep the number of requests to a minimum)

The path with the higher output amount will be used for swapping.

For displaying the token price and deciding when to trigger buy/sell orders, the bot will look at the price of the largest LP, measured by the amount of tokens staked in them. So if token/BNB and token/BUSD both exist, the price will be calculated with the one that has the largest amount of tokens. In the case where BUSD is the largest pool, the price in BUSD/token will be calculated, then the equivalent price in BNB/token will be inferred from the BUSD/BNB price and used for decision making and display.